### PR TITLE
Include psc-package sources list in arguments too if being used

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -108,6 +108,10 @@ When FILENAME is nil or not a real file, returns nil."
       (search-forward-regexp regexp)
       (match-string 1))))
 
+(defun psci/--get-psc-package-sources! ()
+  (when (file-exists-p "psc-package.json")
+    (split-string (shell-command-to-string "psc-package sources"))))
+
 ;; public functions
 
 ;;;###autoload
@@ -128,9 +132,8 @@ Relies on .psci file for determining the project's root folder."
         ;; create the comint process if there is no buffer.
         (unless buffer
           (setq default-directory (psci/--project-root!))
-          (let ((full-arg-list (if (file-exists-p "psc-package.json")
-                                   (let ((psc-package-sources (split-string (shell-command-to-string "psc-package sources"))))
-                                     (append psci/arguments psc-package-sources))
+          (let ((full-arg-list (-if-let (psc-package-sources (psci/--get-psc-package-sources!))
+                                   (append psci/arguments psc-package-sources)
                                  psci/arguments)))
             (apply 'make-comint-in-buffer psci/buffer-name buffer
                    psci-program nil full-arg-list))

--- a/psci.el
+++ b/psci.el
@@ -128,8 +128,12 @@ Relies on .psci file for determining the project's root folder."
         ;; create the comint process if there is no buffer.
         (unless buffer
           (setq default-directory (psci/--project-root!))
-          (apply 'make-comint-in-buffer psci/buffer-name buffer
-                 psci-program nil psci/arguments)
+          (let ((full-arg-list (if (file-exists-p "psc-package.json")
+                                   (let ((psc-package-sources (split-string (shell-command-to-string "psc-package sources"))))
+                                     (append psci/arguments psc-package-sources))
+                                 psci/arguments)))
+            (apply 'make-comint-in-buffer psci/buffer-name buffer
+                   psci-program nil full-arg-list))
           (psci-mode)))
     (psci/log "No .psci file so we cannot determine the root project folder. Please, add one.")))
 


### PR DESCRIPTION
Pulp now supports `psc-package` as well as bower to manage packages. If you've initialised a project with `pulp --psc-package init`, psci is not passed the correct arguments unless you add the big list of output generated by `psc-package sources` to the `psci/arguments` custom variable.

This checks for a `psc-package.json` in the project root which tends to indicate psc-package is being used, and if it finds one, it adds the output from `psc-package sources` to the arguments list which seems to allow the `psci` buffer to start up again.