### PR TITLE
Tab completion

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -167,12 +167,13 @@ Relies on .psci file for determining the project's root folder."
       (remove-hook 'comint-preoutput-filter-functions 'psci-completion-preoutput-filter t)
       (let ((response psci-completion-captured-output))
         (setq psci-completion-captured-output "")
-        (save-excursion
-          (let* ((end (point))
-                 (start (+ (re-search-backward comint-prompt-regexp)
-                           (length psci/prompt)))
-                 (results (psci-tidy-completion-output response)))
-            (list start end results)))))))
+        (when (not (string-prefix-p "Unrecognized directive." response))
+          (save-excursion
+            (let* ((end (point))
+                   (start (+ (re-search-backward comint-prompt-regexp)
+                             (length psci/prompt)))
+                   (results (psci-tidy-completion-output response)))
+              (list start end results))))))))
 
 (defvar psci-dynamic-complete-functions
   '(psci-tab-completion))


### PR DESCRIPTION
Initial basic version of tab completion, using `:completion` directive in psci. This will require https://github.com/purescript/purescript/pull/3038 to be merged and available before it'll work so this is probably still a little way off being useful to a wider audience.

It should just behave the same as it does at the minute if the user is using a purescript version without the :complete directive yet though.

Not convinced I've implemented this the cleanest way - appending repeatedly in the output filter and registering/unregistering output filters via hooks feels a bit dirty, but I couldn't figure out a different way of doing it and it seems to work in all the test cases I could think of! But if anyone knows of a better way please let me know.