### PR TITLE
Fix root detection when projectile fails

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -81,7 +81,7 @@
 (defun psci/--project-root! ()
   "Determine the project's root folder.
 Beware, can return nil if no .psci file is found."
-  (if (fboundp 'projectile-project-root)
+  (if (and (fboundp 'projectile-project-root) (projectile-project-p))
       (projectile-project-root)
     (file-name-directory (buffer-file-name))))
 


### PR DESCRIPTION
projectile-project-root raises, so we need to check if projcetile can recognize
a project with projectile-project-p