### PR TITLE
Add project.el support as an alternative to projectile

### DIFF
--- a/README.org
+++ b/README.org
@@ -121,7 +121,7 @@ M-x el-get-install RET psci RET
 M-x psci
 #+end_src
 
-This will open a psci repl within emacs from your current project root folder (using [[https://github.com/bbatsov/projectile][projectile]] to determine that).
+This will open a psci repl within emacs from your current project root folder (using [[https://github.com/bbatsov/projectile][projectile]] or project.el to determine that).
 
 ** Setup
 

--- a/psci.el
+++ b/psci.el
@@ -85,9 +85,13 @@
 (defun psci--project-root! ()
   "Determine the project's root folder.
 Beware, can return nil if no .psci file is found."
-  (if (and (fboundp 'projectile-project-root) (projectile-project-p))
-      (projectile-project-root)
-    default-directory))
+  (cond
+   ((and (fboundp 'projectile-project-root) (projectile-project-p))
+    (projectile-project-root))
+   ((fboundp 'project-root)
+    (project-root (project-current t)))
+   (t
+    default-directory)))
 
 (defun psci--process-name (buffer-name)
   "Compute the buffer's process name based on BUFFER-NAME."
@@ -136,8 +140,9 @@ Otherwise, just return PATH."
 (defun psci (project-root-folder)
   "Run an inferior instance of \"psci\" inside Emacs, in PROJECT-ROOT-FOLDER.
 If not supplied, the root folder will be guessed using
-`projectile-project-root' (if available), otherwise it will
-default to the current buffer's directory."
+`projectile-project-root', or `project-root' from project.el (if
+available), otherwise it will default to the current buffer's
+directory."
   (interactive (list (read-directory-name "Project root: "
                                           (psci--project-root!))))
   (let* ((default-directory project-root-folder)


### PR DESCRIPTION
If projectile is not available try using project.el to find the root and finally if that isn't loaded then use the default directory