### PR TITLE
look for spago.yaml and add --quiet flag

### DIFF
--- a/psci.el
+++ b/psci.el
@@ -123,8 +123,8 @@ When FILENAME is nil or not a real file, returns nil."
   (cond
    ((file-exists-p "psc-package.json")
     (process-lines (psci--executable-find-relative psci/psc-package-path) "sources"))
-   ((file-exists-p "spago.dhall")
-    (process-lines (psci--executable-find-relative psci/spago-path) "sources"))))
+   ((or (file-exists-p "spago.dhall") (file-exists-p "spago.yaml"))
+    (process-lines (psci--executable-find-relative psci/spago-path) "sources" "--quiet"))))
 
 (defun psci--executable-find-relative (path)
   "If PATH is a relative path to an executable, return its full path.


### PR DESCRIPTION
I was having trouble getting the REPL to work with spago@next, and I realized that the package sources weren't getting picked up because `psci--get-psc-package-sources!` was looking for `spago.dhall` when the latest spago uses a `spago.yaml` file. 

In addition, the stdout would contain log messages that were not relevant, so I added the `--quiet` flag

Maybe resolves https://github.com/purescript-emacs/emacs-psci/issues/30? But I'm not 100% sure what that person encountered. My repl is working with a spago-based project now with the changes I've made.

I'm new to purescript and its ecosystem, so it's possible I'm approaching this the wrong way but please let me know if there's a more appropriate way to approach this and I will make adjustments. Thank you!